### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 description = "Rust access to Python file-like objects"
 license = "Apache-2.0"
-homepage = "https://github.com/jelmer/pyo3-filelike"
+repository = "https://github.com/jelmer/pyo3-filelike"
 
 [dependencies]
 pyo3 = ">=0.20.0"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.